### PR TITLE
chore: remove AGENTS symlink file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,0 @@
-/home/atompowered/python_projects/.agent/AGENTS.md


### PR DESCRIPTION
### Related Issue
N/A

### Description
Removes the repository-level `AGENTS.md` symlink so the repo no longer carries a local pointer to shared agent instructions.

### Changes Made
- Deleted `AGENTS.md` symlink from the repository root.
- Kept behavior aligned with the centralized Codex AGENTS source.

### Testing Performed
- Verified `git status --short` shows only the intended `AGENTS.md` deletion.
